### PR TITLE
AIC-32,34,35

### DIFF
--- a/_code/MainUI_ethics/OfficeFix.aspx
+++ b/_code/MainUI_ethics/OfficeFix.aspx
@@ -7,20 +7,25 @@
     <title></title>
     <link href="Styles/main.css" rel="stylesheet" />
     <script language="javascript" type="text/javascript">
-        var tDoc = '<%= Request.QueryString["tdoc"]%>';
-        var tPtr = '<%= Request.QueryString["tptr"]%>';
-        var prod = '<%= Request.QueryString["prod"]%>';
-        var vct = '<%= Request.QueryString["vct"]%>';
+        var tDoc = '<%= HttpUtility.JavaScriptStringEncode(Request.QueryString["tdoc"]) %>';
+        var tPtr = '<%= HttpUtility.JavaScriptStringEncode(Request.QueryString["tptr"]) %>';
+        var tFldr = '<%= HttpUtility.JavaScriptStringEncode(Request.QueryString["tfldr"]) %>';
+        var prod = '<%= HttpUtility.JavaScriptStringEncode(Request.QueryString["prod"]) %>';
+        var vct = '<%= HttpUtility.JavaScriptStringEncode(Request.QueryString["vct"]) %>';
 
         function directDocLoad() {
-            var Url = 'resourceseamlesslogin.aspx?prod=' + prod + '&tdoc=' + tDoc + '&tPtr=' + tPtr;
-           
+            var Url = 'resourceseamlesslogin.aspx?prod=' + prod + '&tdoc=' + tDoc + '&tptr=' + tPtr;
+
+            if (tFldr) {
+                Url = Url + '&tfldr=' + encodeURIComponent(tFldr);
+            }
+
             if (vct == '1') {
                 Url = Url + "&vct=1";
                 vct = "~" + vct + "~";
-           
+
             }
-           
+
             window.location = Url;
         }
              

--- a/_code/MainUI_ethics/ResourceSeamlessLogin.aspx.cs
+++ b/_code/MainUI_ethics/ResourceSeamlessLogin.aspx.cs
@@ -55,6 +55,7 @@ namespace MainUI
             string resourceName = string.Empty;
             string targetDoc = string.Empty;
             string targetPtr = string.Empty;
+            string targetFolder = string.Empty;
             string docId = string.Empty;
             string docType = string.Empty;
             try
@@ -148,6 +149,12 @@ namespace MainUI
                     targetPtr = Request.QueryString["tptr"];
                 }
                 else targetPtr = string.Empty;
+
+                if (!string.IsNullOrEmpty(Request.QueryString["tfldr"]))
+                {
+                    targetFolder = Request.QueryString["tfldr"];
+                }
+                else targetFolder = string.Empty;
 
                 if (!string.IsNullOrEmpty(Request.QueryString["id"]))
                     docId = Request.QueryString["id"];
@@ -254,6 +261,22 @@ namespace MainUI
                             logEvent.Save(false);
                         }
 
+                        SiteNode targetFolderNode = null;
+                        try
+                        {
+                            targetFolderNode = content.ResolveSiteFolder(targetFolder);
+                        }
+                        catch
+                        {
+                            targetFolderNode = null;
+                        }
+
+                        if (targetFolderNode == null)
+                        {
+                            logEvent = new Event(EventType.Info, DateTime.Now, 1, "ResourceSeamlessLogin.aspx.cs", "Page_Load", "invalid targetfolder", string.Format("invalid targetfolder  {0}", targetFolder));
+                            logEvent.Save(false);
+                        }
+
                         //Log Valid Access
                         logEvent = new Event(EventType.Info, DateTime.Now, 1, "Sharedoc.aspx.cs", "Page_Load", "valid share requested", string.Format(" targetdoc: {0} targetptr: {1} referrer: {2}", targetDoc, targetPtr, referrer));
                         logEvent.Save(false);
@@ -353,7 +376,11 @@ namespace MainUI
 
 
                 bool docRedirect = false;
-                if (targetDoc != string.Empty) {
+                if (targetFolder != string.Empty) {
+                    Url = Url + "?targetfolder=" + HttpUtility.UrlEncode(targetFolder);
+                    docRedirect = true;
+                }
+                else if (targetDoc != string.Empty) {
                     Url = Url + "?targetdoc=" + targetDoc + "&targetptr=" + targetPtr;
                     docRedirect = true;
                 }
@@ -363,7 +390,7 @@ namespace MainUI
                 }
 
 
-                if ((docRedirect) && (viewCompleteTopic))
+                if ((docRedirect) && (viewCompleteTopic) && (targetFolder == string.Empty))
                     Url = Url + "&vct=1";
                 if (Url.StartsWith("default.aspx", StringComparison.CurrentCultureIgnoreCase))
                 {

--- a/_code/MainUI_ethics/WS/Content.asmx.cs
+++ b/_code/MainUI_ethics/WS/Content.asmx.cs
@@ -1258,7 +1258,8 @@ namespace MainUI.WS
         public SiteNode ResolveSiteFolder(string folderName)
         {
             int folderId = 96;
-            
+            bool found = false;
+
             XmlDocument siteXmlDoc = new XmlDocument();
             siteXmlDoc.LoadXml(CurrentSite.SiteXml);
 
@@ -1269,6 +1270,7 @@ namespace MainUI.WS
             if (node != null)
             {
                 folderId = Int32.Parse(node.Attributes.GetNamedItem("Id").Value);
+                found = true;
             }
             else
             {
@@ -1286,12 +1288,17 @@ namespace MainUI.WS
                     if (name == folderName)
                     {
                         folderId = Int32.Parse(listNode.Attributes.GetNamedItem("Id").Value);
+                        found = true;
                         break;
                     }
                 }
             }
 
-            
+            if (!found)
+            {
+                return null;
+            }
+
             ISiteFolder siteFolder = new SiteFolder(CurrentSite, folderId);
 
             SiteNode siteNode = new SiteNode(siteFolder);

--- a/_code/MainUI_ethics/js/webServiceHelpers.js
+++ b/_code/MainUI_ethics/js/webServiceHelpers.js
@@ -848,6 +848,11 @@ function checkAvailable() {
 //         scrollbarPosition (OPTIONAL) - the scrollbar position to goto, if present this will
 //            take precedence over a document anchor / hit highlighting
 function loadContentBySiteNode(siteNode, scrollbarPosition) {
+    if (!siteNode) {
+        fillContentPaneFromUrl("templates/errordirect.html");
+        RemoveEmptyScreens();
+        return;
+    }
     if (siteNode.Restricted && !isLMSLink()) {
         gotoUpsellPage(siteNode.Id, siteNode.Type, g_pageTypes.SCREEN);
         RemoveEmptyScreens();


### PR DESCRIPTION
All three tasks are complete. Final summary across the three files touched for this feature:

- [ResourceSeamlessLogin.aspx.cs](MainUI_ethics/ResourceSeamlessLogin.aspx.cs) — reads `tfldr`, validates it via `ResolveSiteFolder`, logs invalid-folder events, and redirects to `ethics.aspx?targetfolder=...` (no `vct`).
- [Content.asmx.cs](MainUI_ethics/WS/Content.asmx.cs:1258) — `ResolveSiteFolder` now returns `null` on an unmatched folder name instead of silently defaulting to folder 96.
- [webServiceHelpers.js](MainUI_ethics/js/webServiceHelpers.js:850) — `loadContentBySiteNode` guards against a null site node so the home page and toolbar folder links fail gracefully instead of throwing.
- [OfficeFix.aspx](MainUI_ethics/OfficeFix.aspx) — passes `tfldr` through for Word-originated links, encodes all query values with `JavaScriptStringEncode`, and fixes the `tPtr`/`tptr` casing.